### PR TITLE
Let GitHub Actions run for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   deploy:


### PR DESCRIPTION
This PR enables github actions for pull requests, so that we know that PRs don't break the site.