### PR TITLE
Remove Clarivate link

### DIFF
--- a/content/journals.md
+++ b/content/journals.md
@@ -126,7 +126,6 @@ title: Journals
 
 ## Related Resources
 
-- [Journal Citation Reports (Clarivate Analytics)](https://jcr.clarivate.com/JCRLandingPageAction.action): Click *Browse by Journal*, and then choose *Geochemistry&Geophysics*, *Geology*, and *Geosciences, Multidisciplinary* under *Select Catagories*.
 - [Journal Citation Reports (Chinese Academy of Sciences: Geosciences)](http://www.gaokeyan.com/journal/index.php?t=subject&sid=8&p=1&jcr=0) (in Chinese)
 - [Nature Index journals](https://www.natureindex.com/faq#journals)
 - [Journal Abbreviations](https://woodward.library.ubc.ca/research-help/journal-abbreviations/): Search Science and Engineering Journal Abbreviations


### PR DESCRIPTION
Clarivate Journal Citation Reports are not open-access for users
who don't have subscription. So I remove it.

![image](https://user-images.githubusercontent.com/3974108/96819233-21337a80-13f1-11eb-99af-9e714502a26d.png)
